### PR TITLE
Remove link to @jup-ag/core 

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -18,7 +18,6 @@
 
 ## Jupiter SDKs and tools
 
-- [@jup-ag/core npm package](https://www.npmjs.com/package/@jup-ag/core)
 - [quote api nodejs bindings](https://github.com/jup-ag/jupiter-quote-api-node)
 - [nodejs CLI tool to manage fee wallet](https://github.com/jup-ag/jupiter-cli)
 - [jupiter program anchor-gen](https://github.com/jup-ag/jupiter-cpi)


### PR DESCRIPTION
removed @jup-ag/core since it's deprecated